### PR TITLE
Add zoom to `algo.mask_topo`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.o
 *.so
 *.pyc
+*.egg-info
 
 # Packages #
 ############
@@ -39,45 +40,7 @@ Thumbs.db
 *~
 *.swp
 
-# big files #
-#############
-other_docs/*
-src/bmp/summary/*
-src/bmp/data/project/*
 
-
-# tex files #
-#############
-src/bmp/tex/*.pdf
-src/cvc/output/tex/*
-*.aux
-*.out
-*.toc
-*.snm
-*.nav
-
-# test output #
-###############
-src/*/tests/*.pdf
-src/*/tests/*.png
-src/*/tests/*.csv
-src/*/tests/*.tex
-src/*/tests/*.xlsx
-.noseids
-.coverage
-wqio.egg-info/*
-results_images/*
-
-# scratch files #
-#################
-src/scratch/*
-src/bmp/tex/boxplotlegend.png
-*ipython_log*
-*.noseids
-.ipynb_checkpoints
-*.sublime-workspace
-src/*/old/*
-src/bmp/data/old/*
 
 # Visual Studio stuff #
 #######################

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,6 @@ matrix:
     - python: 3.4
       env:
         - COVERAGE=false
-        - NUMPY=1.7
-    - python: 3.4
-      env:
-        - COVERAGE=false
         - NUMPY=1.8
     - python: 3.4
       env:
@@ -45,7 +41,7 @@ install:
   - conda create --yes -n test python=$TRAVIS_PYTHON_VERSION
   - source activate test
   #- conda config --add channels phobson
-  - conda install --yes numpy nose
+  - conda install --yes numpy=$NUMPY scipy nose
   - conda install --yes coverage docopt requests pyyaml
   - pip install coveralls
   - pip install .

--- a/watershed/__init__.py
+++ b/watershed/__init__.py
@@ -1,1 +1,10 @@
-from .algo import flow_direction_d8, trace_upstream, mask_topo
+from .algo import (
+    flow_direction_d8,
+    trace_upstream,
+    mask_topo
+)
+
+from .io import (
+    load_example
+)
+

--- a/watershed/__init__.py
+++ b/watershed/__init__.py
@@ -4,7 +4,7 @@ from .algo import (
     mask_topo
 )
 
-from .io import (
-    load_example
-)
+# from .io import (
+#     load_example
+# )
 

--- a/watershed/tests/test_algo.py
+++ b/watershed/tests/test_algo.py
@@ -2,8 +2,57 @@ import numpy
 
 import nose.tools as nt
 import numpy.testing as nptest
+from scipy import ndimage
 
 from watershed import algo
+
+
+## ESRI Example Datase
+## see: http://goo.gl/UeiaCi
+ESRI_TOPO = numpy.array([
+    [78., 72., 69., 71., 58., 49.],
+    [74., 67., 56., 49., 46., 50.],
+    [69., 53., 44., 37., 38., 48.],
+    [64., 58., 55., 22., 31., 24.],
+    [68., 61., 47., 21., 16., 19.],
+    [74., 53., 34., 12., 11., 12.],
+])
+
+ESRI_FLOW_DIR_D8 = numpy.array([
+    [  2,   2,   2,   4,   4,   8],
+    [  2,   2,   2,   4,   4,   8],
+    [  1,   1,   2,   4,   8,   4],
+    [128, 128,   1,   2,   4,   8],
+    [  2,   2,   1,   4,   4,   4],
+    [  1,   1,   1,   1,  32,  16]
+])
+
+ESRI_UPSTREAM_HIGH = numpy.array([
+    [0, 1, 1, 1, 0, 0],
+    [0, 0, 1, 1, 0, 0],
+    [0, 0, 0, 1, 0, 0],
+    [0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0],
+])
+
+ESRI_UPSTREAM_LOW = numpy.array([
+    [1, 1, 1, 1, 1, 1],
+    [1, 1, 1, 1, 1, 1],
+    [1, 1, 1, 1, 1, 0],
+    [1, 1, 1, 1, 0, 0],
+    [0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0],
+])
+
+ESRI_FLOW_ACC = numpy.array([
+    [ 0,  0,  0,  0,  0,  0],
+    [ 0,  1,  1,  2,  2,  0],
+    [ 0,  3,  7,  5,  4,  0],
+    [ 0,  0,  0, 20,  0,  1],
+    [ 0,  0,  0,  1, 24,  0],
+    [ 0,  2,  4,  6, 35,  2],
+])
 
 
 def test__stack_neighbors():
@@ -25,77 +74,80 @@ def test__stack_neighbors():
     nptest.assert_array_equal(blocks, known_blocks)
 
 
-class base_WatershedMixin(object):
+##
+## Flow Direction tests
+class baseFlowDir_Mixin(object):
     def test_flow_dir_d8(self):
         flow_dir = algo.flow_direction_d8(self.topo)
-        nptest.assert_array_equal(flow_dir, self.known_flow_dir)
+        nptest.assert_array_equal(flow_dir, self.known_flow_dir_d8)
 
+
+class test_flow_direction_arcgis(baseFlowDir_Mixin):
+    def setup(self):
+        self.topo = ESRI_TOPO.copy()
+        self.known_flow_dir_d8 = ESRI_FLOW_DIR_D8.copy()
+
+
+##
+## Trace Upstream Tests
+class baseTraceUpstream_Mixin(object):
     def test_trace_upstream_high(self):
-        upstream = algo.trace_upstream(self.known_flow_dir, self.row_high, self.col_high)
+        upstream = algo.trace_upstream(self.flow_dir, self.row_high, self.col_high)
         nptest.assert_array_equal(upstream, self.known_upstream_high)
 
     def test_trace_upstream_low(self):
-        upstream = algo.trace_upstream(self.known_flow_dir, self.row_low, self.col_low)
+        upstream = algo.trace_upstream(self.flow_dir, self.row_low, self.col_low)
         nptest.assert_array_equal(upstream, self.known_upstream_low)
 
+
+class test_trace_upstream_arcgis(baseTraceUpstream_Mixin):
+    def setup(self):
+        self.flow_dir = ESRI_FLOW_DIR_D8.copy()
+        self.row_high, self.col_high = (2, 3)
+        self.known_upstream_high = ESRI_UPSTREAM_HIGH.copy()
+
+        self.row_low, self.col_low = (3, 3)
+        self.known_upstream_low = ESRI_UPSTREAM_LOW.copy()
+
+
+##
+## Masking Topo tests
+class baseMaskUpstream_Mixin(object):
     def test_mask_topo_upstream(self):
-        masked_topo = algo.mask_topo(self.topo, self.row_high, self.col_high, mask_upstream=True)
+        masked_topo = algo.mask_topo(self.topo, self.row_high, self.col_high,
+                                     zoom_factor=1./self.factor, mask_upstream=True)
         expected = numpy.ma.masked_array(data=self.topo, mask=self.known_upstream_high)
         nptest.assert_array_equal(masked_topo, expected)
 
     def test_mask_topo_not_upstream(self):
-        masked_topo = algo.mask_topo(self.topo, self.row_high, self.col_high, mask_upstream=False)
+        masked_topo = algo.mask_topo(self.topo, self.row_high, self.col_high,
+                                     zoom_factor=1./self.factor, mask_upstream=False)
         mask = numpy.logical_not(self.known_upstream_high)
         expected = numpy.ma.masked_array(data=self.topo, mask=mask)
         nptest.assert_array_equal(masked_topo, expected)
 
 
-class test_arcgis_example(base_WatershedMixin):
+class test_mask_upstream_arcgis(baseMaskUpstream_Mixin):
     def setup(self):
-        self.topo = numpy.array([
-            [78., 72., 69., 71., 58., 49.],
-            [74., 67., 56., 49., 46., 50.],
-            [69., 53., 44., 37., 38., 48.],
-            [64., 58., 55., 22., 31., 24.],
-            [68., 61., 47., 21., 16., 19.],
-            [74., 53., 34., 12., 11., 12.],
-        ])
-
-        self.known_flow_dir = numpy.array([
-            [  2,   2,   2,   4,   4,   8],
-            [  2,   2,   2,   4,   4,   8],
-            [  1,   1,   2,   4,   8,   4],
-            [128, 128,   1,   2,   4,   8],
-            [  2,   2,   1,   4,   4,   4],
-            [  1,   1,   1,   1,  32,  16]
-        ])
-
-
+        self.factor = 1.
+        self.order = 0
+        self.topo = ESRI_TOPO.copy()
         self.row_high, self.col_high = (2, 3)
-        self.known_upstream_high = numpy.array([
-            [0, 1, 1, 1, 0, 0],
-            [0, 0, 1, 1, 0, 0],
-            [0, 0, 0, 1, 0, 0],
-            [0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0],
-        ])
+        self.known_upstream_high = ESRI_UPSTREAM_HIGH.copy()
 
         self.row_low, self.col_low = (3, 3)
-        self.known_upstream_low = numpy.array([
-            [1, 1, 1, 1, 1, 1],
-            [1, 1, 1, 1, 1, 1],
-            [1, 1, 1, 1, 1, 0],
-            [1, 1, 1, 1, 0, 0],
-            [0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0],
-        ])
+        self.known_upstream_low = ESRI_UPSTREAM_LOW.copy()
 
-        self.known_flow_acc = numpy.array([
-            [ 0,  0,  0,  0,  0,  0],
-            [ 0,  1,  1,  2,  2,  0],
-            [ 0,  3,  7,  5,  4,  0],
-            [ 0,  0,  0, 20,  0,  1],
-            [ 0,  0,  0,  1, 24,  0],
-            [ 0,  2,  4,  6, 35,  2],
-        ])
+
+class test_mask_upstream_arcgis_zoomed(baseMaskUpstream_Mixin):
+    def setup(self):
+        self.factor = 2.
+        self.order = 0
+        self.topo = ndimage.zoom(ESRI_TOPO.copy(), self.factor, order=self.order)
+        self.row_high, self.col_high = (2*self.factor, 3*self.factor)
+        self.known_upstream_high = ndimage.zoom(ESRI_UPSTREAM_HIGH.copy(),
+                                                self.factor, order=self.order)
+
+        self.row_low, self.col_low = (3*self.factor, 3*self.factor)
+        self.known_upstream_low = ndimage.zoom(ESRI_UPSTREAM_LOW.copy(),
+                                               self.factor, order=self.order)


### PR DESCRIPTION
When hi-res data doesn't have enough change in elevation in adjacent cells, it help to down-sample the image, determine flow directions, trace upstream, and then un-down-sample the mask.
